### PR TITLE
Alias VIM to Emacs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .DS_Store
 home/.vim/spell
+
+**/.emacs.d/*
+!**/.emacs.d/*.el

--- a/home/.emacs.d/init.el
+++ b/home/.emacs.d/init.el
@@ -1,0 +1,69 @@
+(package-initialize)
+
+(load-theme 'whiteboard t)
+;; Setup standard package archive sources
+(setq package-archives
+      '(("melpa"        . "https://melpa.org/packages/")
+        ("melpa-stable" . "https://stable.melpa.org/packages/")
+        ("gnu"          . "https://elpa.gnu.org/packages/")))
+
+;; Install use-package if not available
+(unless (require 'use-package nil t)
+  (package-refresh-contents)
+  (package-install 'use-package)
+  (require 'use-package))
+
+(use-package evil :ensure t)  
+(require 'evil)
+(evil-mode t)
+
+;; I have no idea WTF is this
+(custom-set-variables
+ ;; custom-set-variables was added by Custom.
+ ;; If you edit it by hand, you could mess it up, so be careful.
+ ;; Your init file should contain only one such instance.
+ ;; If there is more than one, they won't work right.
+ '(package-selected-packages
+   (quote
+    (ac-php auto-complete flycheck flymake-php php-mode evil use-package))))
+(custom-set-faces
+ ;; custom-set-faces was added by Custom.
+ ;; If you edit it by hand, you could mess it up, so be careful.
+ ;; Your init file should contain only one such instance.
+ ;; If there is more than one, they won't work right.
+ )
+
+;; Start emacs more like VIM
+(setq initial-scratch-message "")
+(setq inhibit-startup-message t)
+(scroll-bar-mode 0)
+(tool-bar-mode 0)
+(menu-bar-mode 0)
+
+;; Syntax checking on the fly (need plugins)
+(use-package flycheck :ensure t)
+(require 'flycheck)
+(global-flycheck-mode)
+
+(use-package auto-complete :ensure t)
+(require 'auto-complete)
+
+;; PHP packages
+(use-package php-mode :ensure t)
+(require 'php-mode)
+
+(use-package flymake-php :ensure t)
+(require 'flymake-php)
+(add-hook 'php-mode-hook 'flymake-php-load)
+
+(use-package ac-php :ensure t)
+(add-hook 'php-mode-hook
+    '(lambda ()
+	(auto-complete-mode t)
+	(require 'ac-php)
+	(setq ac-sources  '(ac-source-php ) )
+	(yas-global-mode 1)
+	(define-key php-mode-map  (kbd "C-]") 'ac-php-find-symbol-at-point)   ;goto define
+	(define-key php-mode-map  (kbd "C-t") 'ac-php-location-stack-back   ) ;go back
+	))
+;; ...


### PR DESCRIPTION
I am not currently satisfied with the current setup with Evil mode, there are a lot of things missing which I use a lot and had no interest (in the short time I am playing with this) to find.
## Things I miss (or are currently misconfigured)
- [ ] `:vimgrep` command
- [ ] `<Leader>` mappings for my "after" plugins.
- VIM look & feel:
  - [ ] I removed the toolbar and menu bar, but there are still 3 dots in there annoying me.
  - [ ] Two line status bar, in the same configuration.
  - [ ] `netrw` for project navigation.
## Things I want
- Based on async execution:
  - [ ] Auto complete for huge code bases (tag navigation on evil mode).
  - [ ] Syntactic like linting on-the-fly (almost there).
  - [ ] Unit test execution.
- [ ] Speed: it **needs** to be as faster (or more) than vim. I really don't care if I need to keep Emacs daemon running. It is slow as hell now.
- [ ] `alias vim=emacs -nw`
